### PR TITLE
Update molecule testing for more OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: Ansible role testing
   push:
     branches:
       - master
+      - 20240212-extend-os-support
     paths-ignore:
       - '**.md'
 
@@ -32,6 +33,9 @@ jobs:
           - rockylinux9
           - ubuntu2004
           - ubuntu2204
+          - rhel7
+          - rhel8
+          - rhel9
         python_version:
           - "3.8.16"
           - "3.9.18"
@@ -80,6 +84,9 @@ jobs:
           - rockylinux9
           - ubuntu2004
           - ubuntu2204
+          - rhel7
+          - rhel8
+          - rhel9
 
     steps:
       - name: Check out the Repository.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ name: Ansible role testing
   push:
     branches:
       - master
-      - 20240212-extend-os-support
     paths-ignore:
       - '**.md'
 
@@ -54,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -93,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python3.
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -20,7 +20,10 @@ MOLECULE_DISTRO=centos7 molecule test
     - `ubuntu2204`
     - `ubuntu2004`
     - `centos7`
- - `MOLECULE_PYTHON_VERSION` defines variable `python_version`, default `3.8.16`
+    - `rhel7`
+    - `rhel8`
+    - `rhel9`
+ - `MOLECULE_PYTHON_VERSION` defines variable `python_version`, default `3.11.7`
 
 
 ## Scenario - `install-from-repo`
@@ -42,3 +45,6 @@ MOLECULE_DISTRO=centos7 MOLECULE_PYTHON_VERSION=3.6.10 molecule test
     - `ubuntu2204`
     - `ubuntu2004`
     - `centos7`
+    - `rhel7`
+    - `rhel8`
+    - `rhel9`

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,6 +8,47 @@
         python_install_from_source: true
         python_version: "{{ lookup('env', 'PYTHON_VERSION') }}"
 
+    - name: Install dependencies from CentOS Repositories | RHEL 7+
+      when:
+       - ansible_distribution == "RedHat"
+       - ansible_distribution_major_version == "7"
+      block:
+
+      - set_fact:
+          _tmp_repos:
+            - name: base
+              url: http://mirror.centos.org/centos/7/os/x86_64/
+            - name: sclo
+              url: http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+
+          _tmp_packages:
+            - name: bzip2-devel
+              repo: base
+            - name: devtoolset-11
+              repo: sclo, base
+
+      - name: Add Temporary Repositories | RHEL
+        yum_repository:
+            name: "{{ item.name }}"
+            description: "Centos {{ ansible_distribution_major_version }} - {{ item.name }}"
+            baseurl: "{{ item.url }}"
+            enabled: false
+        with_items: "{{ _tmp_repos }}"
+        loop_control:
+          label: "{{ item.name }}"
+
+      - name: Install missing packages | RHEL
+        yum:
+          name: "{{ item.name }}"
+          state: present
+          enablerepo: "{{ item.repo }}"
+          disable_gpg_check: true
+        with_items: "{{ _tmp_packages }}"
+        loop_control:
+          label: "{{ item.name }}"
+
+
+
     - name: Install prerequisites
       block:
         - name: Update apt cache

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,44 +8,46 @@
         python_install_from_source: true
         python_version: "{{ lookup('env', 'PYTHON_VERSION') }}"
 
+    # package `bzip2-devel` and `devtoolset-11` are not available on UBI7
+    # on RHEL7, they would be available via `rhel-7-server-rpms` and `rhel-7-seerver-rhscl`
     - name: Install dependencies from CentOS Repositories | RHEL 7+
       when:
        - ansible_distribution == "RedHat"
        - ansible_distribution_major_version == "7"
       block:
 
-      - set_fact:
-          _tmp_repos:
-            - name: base
-              url: http://mirror.centos.org/centos/7/os/x86_64/
-            - name: sclo
-              url: http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+        - set_fact:
+            _tmp_repos:
+              - name: base
+                url: http://mirror.centos.org/centos/7/os/x86_64/
+              - name: sclo
+                url: http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 
-          _tmp_packages:
-            - name: bzip2-devel
-              repo: base
-            - name: devtoolset-11
-              repo: sclo, base
+            _tmp_packages:
+              - name: bzip2-devel
+                repo: base
+              - name: devtoolset-11
+                repo: sclo, base
 
-      - name: Add Temporary Repositories | RHEL
-        yum_repository:
+        - name: Add Temporary Repositories | RHEL
+          yum_repository:
+              name: "{{ item.name }}"
+              description: "Centos {{ ansible_distribution_major_version }} - {{ item.name }}"
+              baseurl: "{{ item.url }}"
+              enabled: false
+          with_items: "{{ _tmp_repos }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        - name: Install missing packages | RHEL
+          yum:
             name: "{{ item.name }}"
-            description: "Centos {{ ansible_distribution_major_version }} - {{ item.name }}"
-            baseurl: "{{ item.url }}"
-            enabled: false
-        with_items: "{{ _tmp_repos }}"
-        loop_control:
-          label: "{{ item.name }}"
-
-      - name: Install missing packages | RHEL
-        yum:
-          name: "{{ item.name }}"
-          state: present
-          enablerepo: "{{ item.repo }}"
-          disable_gpg_check: true
-        with_items: "{{ _tmp_packages }}"
-        loop_control:
-          label: "{{ item.name }}"
+            state: present
+            enablerepo: "{{ item.repo }}"
+            disable_gpg_check: true
+          with_items: "{{ _tmp_packages }}"
+          loop_control:
+            label: "{{ item.name }}"
 
 
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest
+    image: miarecdevops/docker-${MOLECULE_DISTRO:-ubuntu2204}-init:latest
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -18,7 +18,7 @@ provisioner:
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
   env:
-    PYTHON_VERSION: ${MOLECULE_PYTHON_VERSION:-3.8.16}
+    PYTHON_VERSION: ${MOLECULE_PYTHON_VERSION:-3.11.7}
 
 verifier:
   name: testinfra

--- a/molecule/install-from-repo/converge.yml
+++ b/molecule/install-from-repo/converge.yml
@@ -7,6 +7,32 @@
     - set_fact:
         python_install_from_source: false
 
+    # packages `python3 ` and `python3-devel` are not available in UBI repositories
+    # in RHEL 7, they would be available in `rhel-7-server-rpms` and `rhel-7-server-optional-rpms`
+    # Adding CentOS BaseOS repository, so that packages can be installed during molecule test
+    - name: Install dependencies from CentOS Repositories | RHEL 7+
+      when:
+       - ansible_distribution == "RedHat"
+       - ansible_distribution_major_version == "7"
+      block:
+        - set_fact:
+            _tmp_repos:
+              - name: base
+                url: http://mirror.centos.org/centos/7/os/x86_64/
+                gpg: http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
+
+        - name: Add Temporary Repositories | RHEL
+          yum_repository:
+              name: "{{ item.name }}"
+              description: "Centos {{ ansible_distribution_major_version }} - {{ item.name }}"
+              baseurl: "{{ item.url }}"
+              enabled: true
+              gpgkey: "{{ item.gpg }}"
+          with_items: "{{ _tmp_repos }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+
     - name: Install prerequisites
       block:
         - name: Update apt cache

--- a/molecule/install-from-repo/molecule.yml
+++ b/molecule/install-from-repo/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest
+    image: miarecdevops/docker-${MOLECULE_DISTRO:-ubuntu2204}-init:latest
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -6,8 +6,8 @@
   with_items:
     - epel-release
   when:
-   - ansible_os_family == "RedHat"
-   - ansible_distribution != "RedHat"
+    - ansible_os_family == "RedHat"
+    - ansible_distribution != "RedHat"
 
 # Install python from package
 - name: Install Python3 packages

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -5,7 +5,9 @@
     state: present
   with_items:
     - epel-release
-  when: ansible_os_family == "RedHat"
+  when:
+   - ansible_os_family == "RedHat"
+   - ansible_distribution != "RedHat"
 
 # Install python from package
 - name: Install Python3 packages

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -23,6 +23,7 @@
   with_items:
     - gcc
     - make
+    - findutils
     - openssl-devel
     - sqlite-devel
     - bzip2-devel

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -73,6 +73,22 @@
         state: present
       when: ansible_distribution == "CentOS"
 
+
+    - name: Install EPEL | RedHat 7
+      when: ansible_distribution == "RedHat"
+      block:
+
+        - name: Import EPEL GPG key | RedHat
+          rpm_key:
+            key: "http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+            state: present
+
+        - name: Install EPEL | RedHat
+          package:
+            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+            state: present
+
+
     - name: Install build dependencies | RedHat 7
       package:
         name: "{{ item }}"

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -51,7 +51,7 @@
 # New GCC version is included in DevToolset
 
 - name: For RedHat 7, install additional build dependencies
-  when: 
+  when:
     - ansible_os_family == "RedHat"
     - ansible_distribution_major_version == '7'
     - python_version is version('3.8', '>=')
@@ -62,6 +62,13 @@
     - name: Install Software Collections (SCL) | CentOS 7
       package:
         name: centos-release-scl
+        state: present
+      when: ansible_distribution == "CentOS"
+
+    # EPEL is required for openssl11 package
+    - name: Install EPEL | CentOS 7
+      package:
+        name: epel-release
         state: present
       when: ansible_distribution == "CentOS"
 
@@ -199,7 +206,7 @@
   args:
     chdir: "{{ python_src_dir_path }}"
     creates: "{{ python_src_dir_path }}/python"
-      
+
 
 - name: Run make altinstall
   command: make altinstall


### PR DESCRIPTION
This PR adds support for the following OS;
- CentOS 7
- Ubuntu 22.04
- Ubuntu 20.04
- Rockylinux 8
- Rockylinux 9
- RHEL 7
- RHEL 8
- RHEL 9